### PR TITLE
added static fields comming from interfaces to implementing classes

### DIFF
--- a/src/src/com/telerik/metadata/Builder.java
+++ b/src/src/com/telerik/metadata/Builder.java
@@ -149,11 +149,11 @@ public class Builder {
 		}
 
 		Field[] fields = clazz.getFields();
-		
-		// adds static fields from interface to implementing class because java can call them from implementing class... no problem.
-		getFieldsFromImplementedInterfaces(clazz, node, root);
 
 		setFieldInfo(clazz, node, root, fields, null);
+
+		// adds static fields from interface to implementing class because java can call them from implementing class... no problem.
+		getFieldsFromImplementedInterfaces(clazz, node, root, fields);
 	}
 
 	private static void setFieldInfo(JavaClass clazz, TreeNode node, TreeNode root, Field[] fields, JavaClass interfaceClass) throws Exception {
@@ -183,15 +183,25 @@ public class Builder {
 		}
 	}
 
-	private static void getFieldsFromImplementedInterfaces(JavaClass clazz, TreeNode node, TreeNode root) throws Exception {
+	private static void getFieldsFromImplementedInterfaces(JavaClass clazz, TreeNode node, TreeNode root, Field[] classFields) throws Exception {
 		Field[] fields = null;
-
+		ArrayList<Field> originalClassFields = (ArrayList<Field>) Arrays.asList(classFields);
+		
 		JavaClass interfaceClass = null;
 		String[] implementedInterfacesNames = clazz.getInterfaceNames();
 		if(implementedInterfacesNames.length > 0) {
 			for(String currInterface : implementedInterfacesNames) {
 				interfaceClass = ClassRepo.findClass(currInterface);
 				fields = interfaceClass.getFields();
+				
+				//if interface and implementing class declare the same static field name the class take precedence
+				if(originalClassFields.size() > 0) {
+					for(Field f : fields) {
+						if(originalClassFields.contains(f)) {
+							return;
+						}
+					}
+				}
 				setFieldInfo(clazz, node, root, fields, interfaceClass);
 			}
 		}

--- a/src/src/com/telerik/metadata/Builder.java
+++ b/src/src/com/telerik/metadata/Builder.java
@@ -86,8 +86,7 @@ public class Builder {
 		return isPublic;
 	}
 
-	private static void generate(JavaClass clazz, TreeNode root)
-			throws Exception {
+	private static void generate(JavaClass clazz, TreeNode root) throws Exception {
 		if (!isClassPublic(clazz)) {
 			return;
 		}
@@ -96,8 +95,7 @@ public class Builder {
 		setNodeMembers(clazz, node, root);
 	}
 
-	private static void setNodeMembers(JavaClass clazz, TreeNode node,
-			TreeNode root) throws Exception {
+	private static void setNodeMembers(JavaClass clazz, TreeNode node, TreeNode root) throws Exception {
 		Map<String, MethodInfo> existingMethods = new HashMap<String, MethodInfo>();
 		for (MethodInfo mi : node.instanceMethods) {
 			existingMethods.put(mi.name + mi.sig, mi);
@@ -151,6 +149,14 @@ public class Builder {
 		}
 
 		Field[] fields = clazz.getFields();
+		
+		// adds static fields from interface to implementing class because java can call them from implementing class... no problem.
+		getFieldsFromImplementedInterfaces(clazz, node, root);
+
+		setFieldInfo(clazz, node, root, fields, null);
+	}
+
+	private static void setFieldInfo(JavaClass clazz, TreeNode node, TreeNode root, Field[] fields, JavaClass interfaceClass) throws Exception {
 		for (Field f : fields) {
 			if (f.isPublic() || f.isProtected()) {
 				FieldInfo fi = new FieldInfo(f.getName());
@@ -158,16 +164,35 @@ public class Builder {
 				Type t = f.getType();
 				boolean isPrimitive = ClassUtil.isPrimitive(t);
 
-				fi.valueType = isPrimitive ? TreeNode.getPrimitive(t)
-						: getOrCreateNode(root, t);
+				fi.valueType = isPrimitive ? TreeNode.getPrimitive(t): getOrCreateNode(root, t);
 				fi.isFinalType = f.isFinal();
 
 				if (f.isStatic()) {
-					fi.declaringType = getOrCreateNode(root, clazz);
+					if(interfaceClass != null) {
+						// changes declaring type of static fields from implementing class to interface
+						fi.declaringType = getOrCreateNode(root, interfaceClass);	
+					}
+					else {
+						fi.declaringType = getOrCreateNode(root, clazz);
+					}
 					node.staticFields.add(fi);
 				} else {
 					node.instanceFields.add(fi);
 				}
+			}
+		}
+	}
+
+	private static void getFieldsFromImplementedInterfaces(JavaClass clazz, TreeNode node, TreeNode root) throws Exception {
+		Field[] fields = null;
+
+		JavaClass interfaceClass = null;
+		String[] implementedInterfacesNames = clazz.getInterfaceNames();
+		if(implementedInterfacesNames.length > 0) {
+			for(String currInterface : implementedInterfacesNames) {
+				interfaceClass = ClassRepo.findClass(currInterface);
+				fields = interfaceClass.getFields();
+				setFieldInfo(clazz, node, root, fields, interfaceClass);
 			}
 		}
 	}
@@ -189,8 +214,7 @@ public class Builder {
 		return node;
 	}
 
-	private static TreeNode getOrCreateNode(TreeNode root, JavaClass clazz)
-			throws Exception {
+	private static TreeNode getOrCreateNode(TreeNode root, JavaClass clazz) throws Exception {
 		if (ClassUtil.isPrimitive(clazz)) {
 			return TreeNode.getPrimitive(clazz);
 		}
@@ -211,8 +235,7 @@ public class Builder {
 					for (InnerClass ic : i) {
 
 						ConstantUtf8 cname = (ConstantUtf8) clazz
-								.getConstantPool().getConstant(
-										ic.getInnerNameIndex());
+								.getConstantPool().getConstant(ic.getInnerNameIndex());
 						String innerClassname = cname.getBytes();
 
 						if (name.equals(innerClassname)) {
@@ -276,7 +299,7 @@ public class Builder {
 				child.nodeType = clazz.isInterface() ? TreeNode.Interface
 						: TreeNode.Class;
 				if (clazz.isStatic()) {
-					child.nodeType |= TreeNode.Static;
+					child.nodeType |= TreeNode.Static; 
 				}
 			}
 		}

--- a/src/src/com/telerik/metadata/Generator.java
+++ b/src/src/com/telerik/metadata/Generator.java
@@ -43,16 +43,13 @@ public class Generator {
 
 		TreeNode root = Builder.build(params);
 
-		FileOutputStream ovs = new FileOutputStream(new File(outName,
-				"treeValueStream.dat"));
+		FileOutputStream ovs = new FileOutputStream(new File(outName,"treeValueStream.dat"));
 		FileStreamWriter outValueStream = new FileStreamWriter(ovs);
 
-		FileOutputStream ons = new FileOutputStream(new File(outName,
-				"treeNodeStream.dat"));
+		FileOutputStream ons = new FileOutputStream(new File(outName,"treeNodeStream.dat"));
 		FileStreamWriter outNodeStream = new FileStreamWriter(ons);
 
-		FileOutputStream oss = new FileOutputStream(new File(outName,
-				"treeStringsStream.dat"));
+		FileOutputStream oss = new FileOutputStream(new File(outName,"treeStringsStream.dat"));
 		FileStreamWriter outStringsStream = new FileStreamWriter(oss);
 
 		new Writer(outNodeStream, outValueStream, outStringsStream)

--- a/src/src/com/telerik/metadata/JarFile.java
+++ b/src/src/com/telerik/metadata/JarFile.java
@@ -38,8 +38,7 @@ public class JarFile implements ClassMapProvider {
 
 			jar = new JarFile(path);
 
-			for (ZipEntry ze = jis.getNextEntry(); ze != null; ze = jis
-					.getNextEntry()) {
+			for (ZipEntry ze = jis.getNextEntry(); ze != null; ze = jis.getNextEntry()) {
 				String name = ze.getName();
 				if (name.endsWith(CLASS_EXT)) {
 					name = name

--- a/src/src/com/telerik/metadata/Writer.java
+++ b/src/src/com/telerik/metadata/Writer.java
@@ -157,7 +157,7 @@ public class Writer {
 		commonInterfacePrefixPosition = writeUniqueName("com/tns/gen/",
 				uniqueStrings, outStringsStream);
 
-		// this while loop fils the treeStringsStream.dat file with a sequence
+		// this while loop fills the treeStringsStream.dat file with a sequence
 		// of the
 		// length and name of all the nodes in the built tree + the primitive
 		// types used by method signatures


### PR DESCRIPTION
* related to: https://github.com/NativeScript/android-runtime/issues/236
* calling `android.provider.ContactsContract.SyncColumns.ACCOUNT_TYPE` is now possible.
* if interface and implementing class declare the same static field name, the class takes precedence (java behavior)